### PR TITLE
Refresh token fixes

### DIFF
--- a/compliant_social_django/storage.py
+++ b/compliant_social_django/storage.py
@@ -187,7 +187,7 @@ class CompliantDjangoUserMixin(DjangoUserMixin):
                                             self.extra_data)
             # break the access token and refresh token out of the extra data
             self.actual_access_token = extra_data.pop('access_token', None)
-            self.actual_refresh_token = extra_data.pop('refresh_token', None)
+            self.actual_refresh_token = extra_data.pop('refresh_token', self.actual_refresh_token)
             if self.set_extra_data(extra_data):
                 self.save()
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -15,21 +15,21 @@ class TestUsers(TestCase):
             user=self.user, provider='my-provider', uid='1234')
 
     def test_user_social_auth_actual_refresh_token_persists_after_calling_refresh_token(self):
+        new_access_token = '123'
+        refresh_token = 'abc'
+
+        self.usa.actual_refresh_token = refresh_token
+        self.usa.actual_access_token = '321'
+
         mock_backend = MagicMock()
         self.usa.get_backend_instance = MagicMock()
         self.usa.get_backend_instance.return_value = mock_backend
-        mock_backend.extra_data.return_value = {'access_token': '123'}
-
-        old_access_token = self.usa.actual_access_token
-        old_refresh_token = self.usa.actual_refresh_token
+        mock_backend.extra_data.return_value = {'access_token': new_access_token}
 
         self.usa.refresh_token(MagicMock())
 
-        new_access_token = '123'
-        new_refresh_token = self.usa.actual_refresh_token
-
-        self.assertEqual(old_refresh_token, new_refresh_token)
-        self.assertNotEqual(old_access_token, new_access_token)
+        self.assertEqual(refresh_token, self.usa.actual_refresh_token)
+        self.assertEqual(new_access_token, self.usa.actual_access_token)
 
     def test_access_token_is_set_to_none_if_access_token_is_not_present_in_response(self):
         mock_backend = MagicMock()
@@ -40,3 +40,22 @@ class TestUsers(TestCase):
         self.usa.refresh_token(MagicMock())
 
         self.assertIsNone(self.usa.actual_access_token)
+
+    def test_user_social_auth_actual_refresh_token_gets_set(self):
+        new_access_token = '123'
+        new_refresh_token = 'abc'
+
+        self.usa.actual_refresh_token = 'cba'
+        self.usa.actual_access_token = '321'
+
+        mock_backend = MagicMock()
+        self.usa.get_backend_instance = MagicMock()
+        self.usa.get_backend_instance.return_value = mock_backend
+        mock_backend.extra_data.return_value = {
+            'access_token': new_access_token,
+            'refresh_token': new_refresh_token}
+
+        self.usa.refresh_token(MagicMock())
+
+        self.assertEqual(new_refresh_token, self.usa.actual_refresh_token)
+        self.assertEqual(new_access_token, self.usa.actual_access_token)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from compliant_social_django.models import UserSocialAuth
+
+
+class TestUsers(TestCase):
+    def setUp(self):
+        self.user_model = get_user_model()
+        self.user = self.user_model.objects.create_user(
+            username='randomtester', email='user@example.com')
+        self.usa = UserSocialAuth.objects.create(
+            user=self.user, provider='my-provider', uid='1234')
+
+    def test_user_social_auth_actual_refresh_token_persists_after_calling_refresh_token(self):
+        mock_backend = MagicMock()
+        self.usa.get_backend_instance = MagicMock()
+        self.usa.get_backend_instance.return_value = mock_backend
+        mock_backend.extra_data.return_value = {'access_token': '123'}
+
+        old_access_token = self.usa.actual_access_token
+        old_refresh_token = self.usa.actual_refresh_token
+
+        self.usa.refresh_token(MagicMock())
+
+        new_access_token = '123'
+        new_refresh_token = self.usa.actual_refresh_token
+
+        self.assertEqual(old_refresh_token, new_refresh_token)
+        self.assertNotEqual(old_access_token, new_access_token)
+
+    def test_access_token_is_set_to_none_if_access_token_is_not_present_in_response(self):
+        mock_backend = MagicMock()
+        self.usa.get_backend_instance = MagicMock()
+        self.usa.get_backend_instance.return_value = mock_backend
+        mock_backend.extra_data.return_value = {}
+
+        self.usa.refresh_token(MagicMock())
+
+        self.assertIsNone(self.usa.actual_access_token)


### PR DESCRIPTION
The thinking here is that the request to refresh the access token will use the refresh token, and return only an access token, not a refresh token. This meant that the function would fall back to None and replace our perfectly good refresh token with that None value, meaning the next time the access token expires that's it, not more auth until you log in again.